### PR TITLE
Add mention for bot verification and update URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ At this time, we are accepting communities which meet the following criteria:
 2.  Your community has at least 1,000 members, or the GitHub repo has at least 1,000 stars.
 3.  Your community adheres to the [Discord community guidelines](https://discordapp.com/guidelines).
 
-While this list does not currently extend to Discord bots, look forward to something for bots in the future.
+Do you own a large bot? Take a look at [veryfying it](https://support.discordapp.com/hc/de/articles/360040720412).
 
 ## Adding your project
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open Source Communities on Discord
 
-This is the source list of OSS communities that use and live on Discord. It is used to populate the list at https://discordapp.com/open-source.
+This is the source list of OSS communities that use and live on Discord. It is used to populate the list at https://discord.com/open-source.
 
 Thanks for being part of Discord!
 
@@ -10,21 +10,21 @@ At this time, we are accepting communities which meet the following criteria:
 
 1.  Your community is not Discord-focused (for example, Discord bots or modifications are not accepted).
 2.  Your community has at least 1,000 members, or the GitHub repo has at least 1,000 stars.
-3.  Your community adheres to the [Discord community guidelines](https://discordapp.com/guidelines).
+3.  Your community adheres to the [Discord community guidelines](https://discord.com/guidelines).
 
-Do you own a large bot? Take a look at [veryfying it](https://support.discordapp.com/hc/en-us/articles/360040720412).
+Do you own a large bot? Take a look at [veryfying it](https://support.discord.com/hc/en-us/articles/360040720412).
 
 ## Adding your project
 
 1.  Fork the repo
-2.  Add your logo into [`/logos`](https://github.com/discordapp/discord-open-source/tree/master/logos)
+2.  Add your logo into [`/logos`](https://github.com/discord/discord-open-source/tree/master/logos)
 
     * Logo dimensions should be either `72x72` for SVG or `144x144` for PNG.
     * Logo should be minified.
-    * Logo should be monochromatic and white (check [the website](https://discordapp.com/open-source) for examples)
+    * Logo should be monochromatic and white (check [the website](https://discord.com/open-source) for examples)
     * SVGs should contain only vector shapes — no raster graphics.
 
-3.  Add your community to [`communities.json`](https://github.com/discordapp/discord-open-source/blob/master/communities.json), like so:
+3.  Add your community to [`communities.json`](https://github.com/discord/discord-open-source/blob/master/communities.json), like so:
 
 ```json
 {
@@ -37,4 +37,4 @@ Do you own a large bot? Take a look at [veryfying it](https://support.discordapp
 }
 ```
 
-4.  Submit a PR with your change, and if all is well, we'll merge it and display it on Discord's [open source page](https://discordapp.com/open-source)!
+4.  Submit a PR with your change, and if all is well, we'll merge it and display it on Discord's [open source page](https://discord.com/open-source)!

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ At this time, we are accepting communities which meet the following criteria:
 2.  Your community has at least 1,000 members, or the GitHub repo has at least 1,000 stars.
 3.  Your community adheres to the [Discord community guidelines](https://discordapp.com/guidelines).
 
-Do you own a large bot? Take a look at [veryfying it](https://support.discordapp.com/hc/de/articles/360040720412).
+Do you own a large bot? Take a look at [veryfying it](https://support.discordapp.com/hc/en-us/articles/360040720412).
 
 ## Adding your project
 


### PR DESCRIPTION
Discord now offers [Bot verification](https://support.discordapp.com/hc/en-us/articles/360040720412) so I believe it would be just right to mention this for all the bot developers that look for a way to get their bot "acknowledged" by Discord.

I hope this is a good approach. I'm open to any changes and suggestions.