### PR TITLE
Adjust the link to the correct Angular Discord

### DIFF
--- a/communities.json
+++ b/communities.json
@@ -20,7 +20,7 @@
       "title": "Angular",
       "quote": "Imagine asking a question and having GDEs and library authors answer, as well as awesome members of the @angular community! That's been my experience. Join the conversation if you haven't already.",
       "quoteSourceUrl": "https://twitter.com/ub3rh4xor/status/1306601883088293889",
-      "inviteCode": "tCXbKXm",
+      "inviteCode": "wC8a8FT",
       "githubUrl": "https://github.com/angular/angular"
     },
     {


### PR DESCRIPTION
By accident I provided the link to the Angular - Russian Community, instead of the intended Angular Global Community - I'm terribly sorry.

Once we get the vanity `discord.gg/angular` link it would be much easier ;) 