### PR TITLE
Fixed wrong image name

### DIFF
--- a/communities.json
+++ b/communities.json
@@ -708,7 +708,7 @@
       "githubUrl": "https://github.com/denoland"
     },
     {
-      "logo": "appwrite.png",
+      "logo": "appwrite.svg",
       "title": "Appwrite",
       "quote": "Discord allowed us to provide better support for our community and a centralized place to discuss and elaborate on future versions.",
       "inviteCode": "GSeTUeA",


### PR DESCRIPTION
Fix for an error when clicking `view more` button on https://discord.com/open-source