### PR TITLE
Update Tachiyomi repository URL.

### DIFF
--- a/communities.json
+++ b/communities.json
@@ -280,7 +280,7 @@
       "title": "Tachiyomi",
       "quote": "Discord is a place where the community provides support for each other, freeing up GitHub issues.",
       "inviteCode": "tachiyomi",
-      "githubUrl": "https://github.com/inorichi/tachiyomi"
+      "githubUrl": "https://github.com/tachiyomiorg/tachiyomi"
     },
     {
       "logo": "luckperms.svg",


### PR DESCRIPTION
Tachiyomi recently moved from a personal repository to an organization repository.