### PR TITLE
Switch to API v9

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -7,7 +7,7 @@ const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 async function validateCommunity(community) {
   while (true) {
-    const req = await fetch(`https://discordapp.com/api/v6/invite/${community.inviteCode}`);
+    const req = await fetch(`https://discordapp.com/api/v9/invite/${community.inviteCode}`);
     const response = await req.json();
 
     if (response.guild) break;


### PR DESCRIPTION
This specifies 9 as the API version in the request URL to be more up-to-date.  It *does not* make any changes to the list of communities.