### PR TITLE
update: api version

### DIFF
--- a/validate.js
+++ b/validate.js
@@ -44,7 +44,7 @@ async function validateCommunity(community, error, warn) {
   await fs.stat(`./logos/${community.logo}`);
 
   while (true) {
-    const req = await fetch(`https://discord.com/api/v9/invites/${community.inviteCode}?with_expiration=1`);
+    const req = await fetch(`https://discord.com/api/v10/invites/${community.inviteCode}?with_expiration=1`);
     const response = await req.json();
 
     if (response.retry_after) {


### PR DESCRIPTION
The Discord API endpoint URL has been updated and it is now necessary to use 'v10' instead of 'v9'. The code has been updated to 'https://discordapp.com/api/v10/invite/' from 'https://discordapp.com/api/v9/invite/'.

[source link](https://github.com/discord/discord-api-docs/discussions/4510)